### PR TITLE
Add missing arity to defoverridable invocation

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -117,7 +117,7 @@ defmodule ExConstructor do
           Keyword.merge(@exconstructor_default_options, opts)
         )
       end
-      defoverridable [{unquote(constructor_name), 2}]
+      defoverridable [{unquote(constructor_name), 1}, {unquote(constructor_name), 2}]
     end
   end
 


### PR DESCRIPTION
The generated constructor has two arities (new/1 and new/2) because of the default argument, but defoverride only declares that the second (new/2) is overridable. If the overriding function uses the same signature as the generated one (with both arities), the following compiler warning is generated:

`script.exs:16: warning: this clause cannot match because a previous clause at line 14 always matches`